### PR TITLE
Set NPM_FLAGS for build environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+  NPM_FLAGS = "--legacy-peer-deps"


### PR DESCRIPTION
- Add NPM Flags cho react-file-viewer (legacy dependency), ép nó chạy trên React 18 trong khi không can thiệp vào các deps khác
- Dựa trên code cũ, chưa chỉnh dynamic, giữ lại các change cần thiết cho netlify chạy thôi 
Lưu ý: Add env phù hợp trên netlify và chỉnh biến SECRETS_SCAN_ENABLED thành false trên đó để có thể build hoàn chỉnh (fix lỗi secret)