### PR TITLE
fix: cho phép đóng banner quảng cáo tải app 

### DIFF
--- a/src/components/AppBanner.js
+++ b/src/components/AppBanner.js
@@ -12,15 +12,6 @@ export default function AppBanner() {
     if (typeof window === "undefined") return;
 
     const handleCheckBanner = () => {
-      // Only show on actual mobile devices, not on PC even with narrow screen
-      const isMobile =
-        /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) &&
-        (window.innerWidth < 768 || ('ontouchstart' in window || navigator.maxTouchPoints > 0));
-      if (!isMobile) {
-        setVisible(false);
-        return;
-      }
-
       // Check if user has closed the banner in the current session
       if (sessionStorage.getItem("app_banner_closed")) {
         setVisible(false);

--- a/src/components/AppBanner.js
+++ b/src/components/AppBanner.js
@@ -12,9 +12,10 @@ export default function AppBanner() {
     if (typeof window === "undefined") return;
 
     const handleCheckBanner = () => {
+      // Only show on actual mobile devices, not on PC even with narrow screen
       const isMobile =
-        /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) ||
-        window.innerWidth < 768;
+        /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) &&
+        (window.innerWidth < 768 || ('ontouchstart' in window || navigator.maxTouchPoints > 0));
       if (!isMobile) {
         setVisible(false);
         return;


### PR DESCRIPTION
for app banner, add a cross at the right top of the banner to remove it (small cross at the right top inside of banner), regardless of pc or phone. banner still seen on first time but user can close it