### PR TITLE
feat(reports): implement content/user report feature

### DIFF
--- a/src/app/Api.js
+++ b/src/app/Api.js
@@ -679,6 +679,23 @@ export const getConversationMentionSuggestions = (conversationId, query) => {
   return Api.getRequest(`/v1.0/chat/conversations/${conversationId}/mention-suggestions?q=${encodeURIComponent(query)}`);
 };
 
+// Reports
+export const reportContent = (params) => {
+  return Api.postRequest("/v1.0/reports", params);
+};
+
+export const getReports = (params = {}) => {
+  return Api.getRequest("/v1.0/reports", params);
+};
+
+export const getReportStats = () => {
+  return Api.getRequest("/v1.0/reports/stats");
+};
+
+export const reviewReport = (id, params) => {
+  return Api.postRequest(`/v1.0/reports/${id}/review`, params);
+};
+
 // Blocking
 export const blockUser = (userId) => {
   return Api.postRequest("/v1.0/users/block", { blocked_user_id: userId });

--- a/src/app/[username]/ProfileClient.js
+++ b/src/app/[username]/ProfileClient.js
@@ -10,8 +10,9 @@ import FollowButton from "@/components/profile/FollowButton";
 import { BsFillGearFill } from "react-icons/bs";
 import { IoChatbubbleEllipsesOutline } from "react-icons/io5";
 import { IoCalendarOutline, IoLocationOutline } from "react-icons/io5";
-import { Edit2Icon } from "lucide-react";
+import { Edit2Icon, Flag } from "lucide-react";
 import { useAuthContext, useChatContext } from "@/contexts/Support";
+import ReportModal from "@/components/ReportModal";
 import {
   followUser,
   unfollowUser,
@@ -26,6 +27,7 @@ export default function ProfileClient({ initialProfile, activeTab, username }) {
   const { currentUser } = useAuthContext();
   const { openChat, createConversation } = useChatContext();
   const router = useRouter();
+  const [showReportModal, setShowReportModal] = useState(false);
 
   // Transform API response to component format
   const transformProfileData = (apiData, currentUsername = null) => {
@@ -733,6 +735,12 @@ export default function ProfileClient({ initialProfile, activeTab, username }) {
 
   return (
     <DefaultLayout activeNav="home">
+      <ReportModal
+        open={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        reportedUserId={profile.id}
+        title="Báo cáo người dùng"
+      />
       <div>
         <div className="flex-1">
           <div className="relative h-36 lg:h-96 overflow-hidden group/cover">
@@ -916,6 +924,14 @@ export default function ProfileClient({ initialProfile, activeTab, username }) {
                       loading={loading}
                       handleFollow={handleFollow}
                     />
+                    <Button
+                      shape="circle"
+                      icon={<Flag className="w-4 h-4" />}
+                      aria-label="Báo cáo"
+                      title="Báo cáo người dùng"
+                      onClick={() => setShowReportModal(true)}
+                      className="!flex !items-center !justify-center"
+                    />
                   </>
                 )}
               </div>
@@ -984,6 +1000,7 @@ export default function ProfileClient({ initialProfile, activeTab, username }) {
                   <>
                     <Button shape="circle" icon={<IoChatbubbleEllipsesOutline className="w-5 h-5 mt-1" />} aria-label="Nhắn tin" title="Nhắn tin" loading={messaging} onClick={handleMessage} className="!flex !items-center !justify-center !border-[#319527]" />
                     <FollowButton isFollowing={isFollowing} loading={loading} handleFollow={handleFollow} />
+                    <Button shape="circle" icon={<Flag className="w-4 h-4" />} aria-label="Báo cáo" title="Báo cáo người dùng" onClick={() => setShowReportModal(true)} className="!flex !items-center !justify-center" />
                   </>
                 )}
               </div>
@@ -1132,6 +1149,14 @@ export default function ProfileClient({ initialProfile, activeTab, username }) {
                       isFollowing={isFollowing}
                       loading={loading}
                       handleFollow={handleFollow}
+                    />
+                    <Button
+                      shape="circle"
+                      icon={<Flag className="w-4 h-4" />}
+                      aria-label="Báo cáo"
+                      title="Báo cáo người dùng"
+                      onClick={() => setShowReportModal(true)}
+                      className="!flex !items-center !justify-center"
                     />
                   </>
                 )}

--- a/src/app/admin/reports/page.js
+++ b/src/app/admin/reports/page.js
@@ -1,0 +1,371 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  Table,
+  Tag,
+  Select,
+  DatePicker,
+  Button,
+  Modal,
+  Input,
+  Switch,
+  InputNumber,
+  message,
+  Card,
+  Row,
+  Col,
+  Statistic,
+} from "antd";
+import DefaultLayout from "@/layouts/DefaultLayout";
+import { useAuthContext } from "@/contexts/Support";
+import { getReports, getReportStats, reviewReport } from "@/app/Api";
+
+const { RangePicker } = DatePicker;
+const { TextArea } = Input;
+
+const STATUS_COLORS = {
+  pending: "orange",
+  reviewed: "blue",
+  resolved: "green",
+  dismissed: "default",
+};
+
+const STATUS_LABELS = {
+  pending: "Chờ xử lý",
+  reviewed: "Đã xem xét",
+  resolved: "Đã giải quyết",
+  dismissed: "Đã bỏ qua",
+};
+
+function ReviewModal({ report, open, onClose, onSuccess }) {
+  const [status, setStatus] = useState("reviewed");
+  const [adminNotes, setAdminNotes] = useState("");
+  const [banUser, setBanUser] = useState(false);
+  const [banDuration, setBanDuration] = useState(7);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setStatus("reviewed");
+      setAdminNotes("");
+      setBanUser(false);
+      setBanDuration(7);
+    }
+  }, [open, report?.id]);
+
+  const handleSubmit = async () => {
+    if (!adminNotes.trim()) {
+      message.error("Vui lòng nhập ghi chú xử lý");
+      return;
+    }
+    if (banUser && (!banDuration || banDuration < 1)) {
+      message.error("Vui lòng nhập số ngày cấm hợp lệ");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const params = {
+        status,
+        admin_notes: adminNotes.trim(),
+        ban_user: banUser,
+      };
+      if (banUser) params.ban_duration = banDuration;
+
+      await reviewReport(report.id, params);
+      message.success("Đã cập nhật báo cáo");
+      onSuccess?.();
+      onClose?.();
+    } catch (err) {
+      message.error(
+        err?.response?.data?.message || "Không thể cập nhật báo cáo, vui lòng thử lại"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={`Xử lý báo cáo #${report?.id ?? ""}`}
+      onCancel={() => !submitting && onClose?.()}
+      onOk={handleSubmit}
+      okText="Lưu"
+      cancelText="Hủy"
+      okButtonProps={{ loading: submitting }}
+      cancelButtonProps={{ disabled: submitting }}
+      destroyOnClose
+    >
+      <div className="flex flex-col gap-3">
+        <div>
+          <label className="block text-sm font-medium mb-1">Trạng thái</label>
+          <Select
+            className="w-full"
+            value={status}
+            onChange={setStatus}
+            options={[
+              { value: "reviewed", label: "Đã xem xét" },
+              { value: "resolved", label: "Đã giải quyết" },
+              { value: "dismissed", label: "Đã bỏ qua" },
+            ]}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Ghi chú xử lý</label>
+          <TextArea
+            rows={3}
+            value={adminNotes}
+            onChange={(e) => setAdminNotes(e.target.value)}
+            placeholder="Nhập ghi chú xử lý báo cáo này..."
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch checked={banUser} onChange={setBanUser} />
+          <span className="text-sm">Cấm người dùng bị báo cáo</span>
+        </div>
+        {banUser && (
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Số ngày cấm
+            </label>
+            <InputNumber
+              min={1}
+              value={banDuration}
+              onChange={setBanDuration}
+              className="w-full"
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export default function AdminReportsPage() {
+  const { currentUser, authLoading } = useAuthContext();
+  const [reports, setReports] = useState([]);
+  const [pagination, setPagination] = useState({ current: 1, pageSize: 15, total: 0 });
+  const [loading, setLoading] = useState(false);
+  const [statusFilter, setStatusFilter] = useState(null);
+  const [dateRange, setDateRange] = useState(null);
+  const [stats, setStats] = useState(null);
+  const [reviewTarget, setReviewTarget] = useState(null);
+
+  const isAdmin = currentUser?.role === "admin";
+
+  const fetchReports = useCallback(
+    async (page = 1) => {
+      setLoading(true);
+      try {
+        const params = { page };
+        if (statusFilter) params.status = statusFilter;
+        if (dateRange?.[0]) params.from_date = dateRange[0].format("YYYY-MM-DD");
+        if (dateRange?.[1]) params.to_date = dateRange[1].format("YYYY-MM-DD");
+
+        const res = await getReports(params);
+        const data = res.data;
+        setReports(data?.data || []);
+        setPagination({
+          current: data?.current_page || 1,
+          pageSize: data?.per_page || 15,
+          total: data?.total || 0,
+        });
+      } catch (err) {
+        message.error(
+          err?.response?.data?.message || "Không thể tải danh sách báo cáo"
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [statusFilter, dateRange]
+  );
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const res = await getReportStats();
+      setStats(res.data);
+    } catch (err) {
+      // Non-fatal; just skip the stats summary if it fails.
+      console.error("Failed to load report stats:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    fetchReports(1);
+    fetchStats();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin, statusFilter, dateRange]);
+
+  if (authLoading) {
+    return (
+      <DefaultLayout activeNav="admin">
+        <div className="p-8 text-center text-gray-500">Đang tải...</div>
+      </DefaultLayout>
+    );
+  }
+
+  if (!currentUser || !isAdmin) {
+    return (
+      <DefaultLayout activeNav="admin">
+        <div className="p-8 text-center">
+          <h1 className="text-xl font-semibold mb-2">Không có quyền truy cập</h1>
+          <p className="text-gray-500 mb-4">
+            Bạn cần quyền quản trị viên để xem trang này.
+          </p>
+          <Link href="/" className="text-primary-500 underline">
+            Về trang chủ
+          </Link>
+        </div>
+      </DefaultLayout>
+    );
+  }
+
+  const columns = [
+    { title: "ID", dataIndex: "id", key: "id", width: 70 },
+    {
+      title: "Người báo cáo",
+      key: "reporter",
+      render: (_, r) => r.reporter?.username || r.reporter?.profile_name || "-",
+    },
+    {
+      title: "Người bị báo cáo",
+      key: "reportedUser",
+      render: (_, r) =>
+        r.reportedUser?.username || r.reportedUser?.profile_name || "-",
+    },
+    {
+      title: "Nội dung liên quan",
+      key: "content",
+      render: (_, r) => {
+        if (r.topic_id) return `Bài viết #${r.topic_id}`;
+        if (r.story_id) return `Tin #${r.story_id}`;
+        return "Người dùng";
+      },
+    },
+    {
+      title: "Lý do",
+      dataIndex: "reason",
+      key: "reason",
+      ellipsis: true,
+    },
+    {
+      title: "Trạng thái",
+      dataIndex: "status",
+      key: "status",
+      render: (status) => (
+        <Tag color={STATUS_COLORS[status] || "default"}>
+          {STATUS_LABELS[status] || status}
+        </Tag>
+      ),
+    },
+    {
+      title: "Ngày tạo",
+      dataIndex: "created_at",
+      key: "created_at",
+      render: (v) => (v ? new Date(v).toLocaleString("vi-VN") : "-"),
+    },
+    {
+      title: "",
+      key: "actions",
+      render: (_, r) => (
+        <Button size="small" onClick={() => setReviewTarget(r)}>
+          Xử lý
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <DefaultLayout activeNav="admin">
+      <div className="max-w-[1100px] mx-auto w-full px-4 py-6">
+        <h1 className="text-xl font-semibold mb-4">Quản lý báo cáo</h1>
+
+        {stats && (
+          <Row gutter={[16, 16]} className="mb-6">
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Tổng số" value={stats.total} /></Card>
+            </Col>
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Chờ xử lý" value={stats.pending} /></Card>
+            </Col>
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Đã xem xét" value={stats.reviewed} /></Card>
+            </Col>
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Đã giải quyết" value={stats.resolved} /></Card>
+            </Col>
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Đã bỏ qua" value={stats.dismissed} /></Card>
+            </Col>
+            <Col xs={12} sm={8} md={4}>
+              <Card size="small"><Statistic title="Gần đây" value={stats.recent} /></Card>
+            </Col>
+          </Row>
+        )}
+
+        {stats?.most_reported_users?.length > 0 && (
+          <Card size="small" title="Người dùng bị báo cáo nhiều nhất" className="mb-6">
+            <div className="flex flex-col gap-1">
+              {stats.most_reported_users.map((r, idx) => (
+                <div key={r.reported_user_id || idx} className="flex justify-between text-sm">
+                  <span>
+                    {r.reportedUser?.username ||
+                      r.reportedUser?.profile_name ||
+                      `#${r.reported_user_id}`}
+                  </span>
+                  <span className="text-gray-500">{r.total} lượt</span>
+                </div>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        <div className="flex flex-wrap gap-3 mb-4">
+          <Select
+            allowClear
+            placeholder="Lọc theo trạng thái"
+            className="w-48"
+            value={statusFilter}
+            onChange={setStatusFilter}
+            options={[
+              { value: "pending", label: "Chờ xử lý" },
+              { value: "reviewed", label: "Đã xem xét" },
+              { value: "resolved", label: "Đã giải quyết" },
+              { value: "dismissed", label: "Đã bỏ qua" },
+            ]}
+          />
+          <RangePicker value={dateRange} onChange={setDateRange} />
+        </div>
+
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={reports}
+          loading={loading}
+          pagination={{
+            current: pagination.current,
+            pageSize: pagination.pageSize,
+            total: pagination.total,
+            onChange: (page) => fetchReports(page),
+          }}
+          scroll={{ x: true }}
+        />
+      </div>
+
+      <ReviewModal
+        report={reviewTarget}
+        open={!!reviewTarget}
+        onClose={() => setReviewTarget(null)}
+        onSuccess={() => {
+          fetchReports(pagination.current);
+          fetchStats();
+        }}
+      />
+    </DefaultLayout>
+  );
+}

--- a/src/components/ReportModal.js
+++ b/src/components/ReportModal.js
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { Modal, Input, message } from "antd";
+import { reportContent } from "@/app/Api";
+
+const { TextArea } = Input;
+
+/**
+ * Reusable report dialog.
+ *
+ * Pass exactly one of `topicId` / `storyId`, or neither for a plain user
+ * report. `reportedUserId` should be supplied whenever it's known (it's
+ * required by the backend unless it can be resolved from the topic/story).
+ */
+export default function ReportModal({
+  open,
+  onClose,
+  reportedUserId = null,
+  topicId = null,
+  storyId = null,
+  title = "Báo cáo",
+  onSuccess,
+}) {
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleClose = () => {
+    if (submitting) return;
+    setReason("");
+    setError(null);
+    onClose?.();
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = reason.trim();
+    if (!trimmed) {
+      setError("Vui lòng nhập lý do báo cáo");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const params = { reason: trimmed };
+      if (reportedUserId) params.reported_user_id = reportedUserId;
+      if (topicId) params.topic_id = topicId;
+      if (storyId) params.story_id = storyId;
+
+      await reportContent(params);
+      message.success("Đã gửi báo cáo. Cảm ơn bạn đã phản hồi!");
+      setReason("");
+      onSuccess?.();
+      onClose?.();
+    } catch (err) {
+      const serverMessage = err?.response?.data?.message;
+      if (serverMessage === "You cannot report yourself") {
+        message.error("Bạn không thể tự báo cáo chính mình.");
+      } else if (
+        serverMessage === "You have already reported this user/content"
+      ) {
+        message.error("Bạn đã báo cáo nội dung/người dùng này rồi.");
+      } else if (serverMessage === "Cannot determine user to report") {
+        message.error("Không thể xác định người dùng để báo cáo.");
+      } else {
+        message.error(serverMessage || "Không thể gửi báo cáo, vui lòng thử lại.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={title}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText="Gửi báo cáo"
+      cancelText="Hủy"
+      okButtonProps={{ loading: submitting, danger: true }}
+      cancelButtonProps={{ disabled: submitting }}
+      destroyOnClose
+    >
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+        Hãy cho chúng tôi biết lý do bạn báo cáo nội dung/người dùng này. Đội
+        ngũ quản trị sẽ xem xét báo cáo của bạn sớm nhất có thể.
+      </p>
+      <TextArea
+        rows={4}
+        value={reason}
+        onChange={(e) => {
+          setReason(e.target.value);
+          if (error) setError(null);
+        }}
+        placeholder="Nhập lý do báo cáo..."
+        maxLength={1000}
+        disabled={submitting}
+      />
+      {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
+    </Modal>
+  );
+}

--- a/src/components/chat/ChatHeader.js
+++ b/src/components/chat/ChatHeader.js
@@ -9,9 +9,12 @@ import {
   ChevronUp,
   ChevronLeft,
   X,
+  Flag,
 } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import ReportModal from "@/components/ReportModal";
 
 export default function ChatHeader({
   conversation,
@@ -27,6 +30,9 @@ export default function ChatHeader({
   showNewGroupDialog,
 }) {
   const isThreadsView = !conversation;
+  const [showReportModal, setShowReportModal] = useState(false);
+  const otherParticipant =
+    conversation?.type !== "group" ? conversation?.participants?.[0] : null;
 
   return (
     <div className="flex items-center justify-between rounded-lg px-4 py-3 bg-white dark:bg-neutral-700">
@@ -178,6 +184,15 @@ export default function ChatHeader({
             <ImageIcon className="w-4 h-4 text-gray-600 dark:text-gray-300" />
           </button>
         )}
+        {conversation?.id && conversation?.type !== "group" && otherParticipant?.id && (
+          <button
+            onClick={() => setShowReportModal(true)}
+            className="p-1.5 hover:bg-gray-100 dark:hover:bg-neutral-600 rounded transition-colors"
+            title="Báo cáo người dùng"
+          >
+            <Flag className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+          </button>
+        )}
         <button
           onClick={onMinimize}
           className="p-1.5 hover:bg-gray-100 dark:hover:bg-neutral-600 rounded transition-colors"
@@ -197,6 +212,12 @@ export default function ChatHeader({
           <X className="w-4 h-4 text-gray-600 dark:text-gray-300" />
         </button>
       </div>
+      <ReportModal
+        open={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        reportedUserId={otherParticipant?.id}
+        title="Báo cáo người dùng"
+      />
     </div>
   );
 }

--- a/src/components/forum/PostItem.js
+++ b/src/components/forum/PostItem.js
@@ -50,6 +50,7 @@ import {
 import { usePostRefresh } from "@/contexts/PostRefreshContext";
 import CreatePostModal from "../modals/CreatePostModal";
 import PostVotesModal from "./PostVotesModal";
+import ReportModal from "@/components/ReportModal";
 
 export default function PostItem({ post, single = false, onVote, onRefresh = null }) {
   const { currentUser, refreshUser } = useAuthContext();
@@ -57,6 +58,7 @@ export default function PostItem({ post, single = false, onVote, onRefresh = nul
   const [showFullContent, setShowFullContent] = useState(false);
   const [isSaved, setIsSaved] = useState(!!(post.is_saved || post.saved));
   const [showVotesModal, setShowVotesModal] = useState(false);
+  const [showReportModal, setShowReportModal] = useState(false);
   const maxLength = 300; // Số ký tự tối đa trước khi truncate
   const myVote =
     post.votes?.find((v) => v.username === currentUser?.username)?.vote_value ||
@@ -385,7 +387,11 @@ export default function PostItem({ post, single = false, onVote, onRefresh = nul
   };
 
   const handleReport = () => {
-    message.info("Tính năng đang phát triển");
+    if (!currentUser) {
+      message.warning("Bạn cần đăng nhập để báo cáo bài viết.");
+      return;
+    }
+    setShowReportModal(true);
   };
 
   const menuItems = [
@@ -444,6 +450,13 @@ export default function PostItem({ post, single = false, onVote, onRefresh = nul
         postId={post.id}
         postTitle={post.title}
         onClose={() => setShowVotesModal(false)}
+      />
+      <ReportModal
+        open={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        reportedUserId={post.author?.id}
+        topicId={post.id}
+        title="Báo cáo bài viết"
       />
       <div className="post-container-post post-container mb-4 shadow-lg rounded-xl !p-6 bg-white flex flex-col-reverse md:flex-row">
         <div className="min-w-[72px]">

--- a/src/components/stories/StoryViewer.js
+++ b/src/components/stories/StoryViewer.js
@@ -6,12 +6,13 @@ import { Drawer, message } from "antd";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { EffectCube } from "swiper/modules";
 import { useRouter } from "@bprogress/next/app";
-import { X, ChevronLeft, ChevronRight, VolumeX, Volume2, Link2, Smartphone, Trash2, Send } from "lucide-react";
+import { X, ChevronLeft, ChevronRight, VolumeX, Volume2, Link2, Smartphone, Trash2, Send, Flag } from "lucide-react";
 import { markStoryAsViewed, deleteStory, reactToStory, removeStoryReaction } from "@/app/Api";
 import { postRequest } from "@/services/api/ApiByAxios";
 import { Modal } from "antd";
 import Link from "next/link";
 import { openDeepLink } from "@/lib/deepLink";
+import ReportModal from "@/components/ReportModal";
 
 // Import Swiper styles
 import "swiper/css";
@@ -87,8 +88,11 @@ const UserHeader = ({
   isOwner,
   onDelete,
   isMuteLocked,
+  currentUser,
+  reportedUserId,
 }) => {
   const [isMobile, setIsMobile] = useState(false);
+  const [showReportModal, setShowReportModal] = useState(false);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -193,6 +197,21 @@ const UserHeader = ({
             <Trash2 className="w-5 h-5 sm:w-6 sm:h-6 drop-shadow" />
           </button>
         )}
+        {!isOwner && (
+          <button
+            onClick={() => {
+              if (!currentUser) {
+                message.warning("Bạn cần đăng nhập để báo cáo.");
+                return;
+              }
+              setShowReportModal(true);
+            }}
+            className="text-white hover:text-red-400 transition-colors p-1.5 sm:p-2 flex-shrink-0"
+            title="Báo cáo tin này"
+          >
+            <Flag className="w-5 h-5 sm:w-6 sm:h-6 drop-shadow" />
+          </button>
+        )}
         <button
           onClick={onClose}
           className="text-white hover:text-white/80 transition-colors p-1.5 sm:p-2 flex-shrink-0"
@@ -200,6 +219,13 @@ const UserHeader = ({
           <X className="w-5 h-5 sm:w-6 sm:h-6 drop-shadow" />
         </button>
       </div>
+      <ReportModal
+        open={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        reportedUserId={reportedUserId}
+        storyId={storyId}
+        title="Báo cáo tin"
+      />
     </div>
   );
 };
@@ -698,6 +724,8 @@ const StorySlide = ({
         storyId={currentStory?.id}
         isMuteLocked={Boolean(currentStory?.is_muted)}
         isOwner={isOwner}
+        currentUser={currentUser}
+        reportedUserId={user?.id}
         onDelete={() => {
           Modal.confirm({
             title: "Xóa tin này?",


### PR DESCRIPTION
## Summary
- Replaces the stubbed "Báo cáo bài viết" menu item (which only showed a "feature under development" toast) with a real report flow calling the backend `POST /reports` API.
- Adds a reusable `ReportModal` component (`src/components/ReportModal.js`) with reason input, loading state, and success/duplicate/self-report/generic error toasts.
- Wires report actions into:
  - Post/topic report in `PostItem.js` (also covers the post detail page, which reuses `PostItem`).
  - Story viewer (`StoryViewer.js`) — report a story owner.
  - Chat header (`ChatHeader.js`) — report the other participant in a 1:1 conversation.
  - User profile page (`ProfileClient.js`) — report a user directly (desktop + mobile layouts).
- Adds an admin dashboard at `/admin/reports` (`src/app/admin/reports/page.js`): stats summary, filterable/paginated reports table, and a review modal (status, admin notes, optional ban with duration) calling `POST /reports/{id}/review`. Gated client-side via `currentUser.role === "admin"`, matching the existing pattern in `PostItem.js`; the backend's `role:admin` middleware remains the real security boundary.

## Test plan
- [x] `npm run lint` — no new errors (pre-existing warnings only, none touching new files)
- [x] `npm run build` — succeeds, `/admin/reports` compiles as a static route
- [ ] Manual QA: report a post, a story, a chat user, and a profile; verify duplicate/self-report error toasts; verify admin review + ban flow against a live backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)