### PR TITLE
fix(quiz): derive answer letter from option index, not option text

### DIFF
--- a/src/app/explore/quiz/QuizClient.js
+++ b/src/app/explore/quiz/QuizClient.js
@@ -566,8 +566,9 @@ export default function QuizClient() {
                     {currentQuestion.question}
                   </p>
                   <div className="flex flex-col gap-2">
-                    {currentQuestion.options.map((opt) => {
-                      const letter = opt.trim().charAt(0);
+                    {currentQuestion.options.map((opt, optIndex) => {
+                      if (opt.trim() === "") return null;
+                      const letter = ["A", "B", "C", "D"][optIndex];
                       const selected = answers[currentQuestion.id] === letter;
                       const isCorrectOption = currentFeedback && letter === currentFeedback.correct_answer;
                       const isWrongSelected = currentFeedback && selected && !currentFeedback.is_correct;
@@ -698,8 +699,9 @@ export default function QuizClient() {
                       <p className="font-medium text-gray-900 dark:text-white">{q.question}</p>
                     </div>
                     <div className="pl-7 flex flex-col gap-1">
-                      {q.options.map((opt) => {
-                        const letter = opt.trim().charAt(0);
+                      {q.options.map((opt, optIndex) => {
+                        if (opt.trim() === "") return null;
+                        const letter = ["A", "B", "C", "D"][optIndex];
                         const isCorrect = letter === r.correct_answer;
                         const isYours = letter === r.your_answer;
                         return (


### PR DESCRIPTION
## Summary
- Custom quizzes with plain-text options (no "A. "/"B. " prefix) sent garbage/invalid answer letters, triggering a 422 from the backend's `in:A,B,C,D` validation.
- Fixes both the quiz-taking screen and the results screen to compute the letter from the option's index instead of parsing its first character, and skips empty placeholder options used to pad custom quizzes under 4 real choices.

## Test plan
- [ ] Create a custom quiz with only 2 options (e.g. A/B) and confirm selecting either answers correctly without a 422
- [ ] Confirm AI-generated quizzes (with "A. "-prefixed options) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)